### PR TITLE
Bugfix at end of paragraph

### DIFF
--- a/english.lisp
+++ b/english.lisp
@@ -17,7 +17,7 @@
         with length = (length string)
         for word-start = (find-start string position)
         for word-end = (find-end string word-start)
-        while (/= word-start word-end length)
+        until (= word-start word-end length)
         do (setf position word-end)
         unless (english-lookup (subseq string word-start word-end))
           collect (cons word-start word-end)))


### PR DESCRIPTION
`(english-check-paragraph "sdfsdfdsfdf")` used to return `NIL` while it's supposed to return `((0 . 11))`. This fixes the issue.