### PR TITLE
Fixes

### DIFF
--- a/code/compact-trie.lisp
+++ b/code/compact-trie.lisp
@@ -299,7 +299,14 @@
 ;;; We would normally define `compact-leaf-node' here, but there is no
 ;;; `compact-leaf-node' class since `compact-node' for `raw-leaf-node'
 ;;; returns the entries directly instead of wrapping them in a leaf
-;;; node.
+;;; node. A lookup in there entries can only succeed if the suffix is
+;;; already 0.
+
+(defmethod %lookup ((function function)
+                    (string   string)
+                    (suffix   integer)
+                    (node     t))
+  nil)
 
 (defmethod %lookup ((function function)
                     (string   string)

--- a/code/compact-trie.lisp
+++ b/code/compact-trie.lisp
@@ -281,7 +281,7 @@
 (defmethod %lookup ((function function)
                     (string   string)
                     (suffix   (eql 0))
-                    (nodef    compact-interior-node))
+                    (node     compact-interior-node))
   nil)
 
 (defmethod compact-node ((node raw-interior-node) (depth integer))

--- a/code/compact-trie.lisp
+++ b/code/compact-trie.lisp
@@ -152,7 +152,7 @@
 (deftype compact-child-cell ()
   '(cons child-key compact-child-value))
 
-(defun %every-compact-child-chell (object)
+(defun %every-compact-child-cell (object)
   (and (typep object 'sequence)
        (let ((length (length object)))
          (and (zerop (mod length 2))
@@ -163,7 +163,7 @@
                                  (typep child 'compact-child-value)))))))
 
 (deftype vector-of-compact-child-cell ()
-  '(and (simple-array t 1) (satisfies %every-compact-child-chell)))
+  '(and (simple-array t 1) (satisfies %every-compact-child-cell)))
 
 (deftype compact-child-cells ()
   '(or compact-child-cell vector-of-compact-child-cell))

--- a/spell.asd
+++ b/spell.asd
@@ -1,33 +1,45 @@
 (defsystem "spell"
   :description "Spellchecking package for Common Lisp"
-  :author ("Robert Strandh <robert.strandh@gmail.com>"
-           "Michał \"phoe\" Herda <phoe@disroot.org>"
-           "Jan Moringen <jan.moringen@posteo.de>")
-  :license "BSD"
-  :version (:read-file-form "data/version-string.sexp")
-  :depends-on ("closer-mop"
-               "alexandria"
-               "utilities.print-items"
-               "bitfield")
-  :components ((:module     "code"
-                :serial     t
-                :components ((:file "package")
-                             (:file "protocol")
-                             ;; Utilities
-                             (:file "bitfield-class")
-                             (:file "strings")
-                             (:file "text-file")
-                             ;; Words
-                             (:file "word-class") ; metaclass
-                             (:file "word-classes")
-                             ;; Trie
-                             (:file "trie")
-                             (:file "raw-trie")
-                             (:file "compact-trie")
-                             (:file "shared-trie")
-                             ;; Dictionary
-                             (:file "dictionary")
-                             (:file "english"))))
+  :license     "BSD"
+  :author      ("Robert Strandh <robert.strandh@gmail.com>"
+                "Michał \"phoe\" Herda <phoe@disroot.org>"
+                "Jan Moringen <jan.moringen@posteo.de>")
+
+  :version     (:read-file-form "data/version-string.sexp")
+  :depends-on  ("closer-mop"
+                "alexandria"
+                "utilities.print-items"
+                "bitfield")
+
+  :components  ((:module     "code"
+                 :serial     t
+                 :components ((:file "package")
+                              (:file "protocol")
+                              ;; Utilities
+                              (:file "bitfield-class")
+                              (:file "strings")
+                              (:file "text-file")
+                              ;; Words
+                              (:file "word-class") ; metaclass
+                              (:file "word-classes")
+                              ;; Trie
+                              (:file "trie")
+                              (:file "raw-trie")
+                              (:file "compact-trie")
+                              (:file "shared-trie")
+                              ;; Dictionary
+                              (:file "dictionary")))
+
+                (:module     "english-dictionary-data"
+                 :pathname   "data"
+                 :components ((:static-file "english.txt")
+                              (:static-file "english-additions.txt")))
+
+                (:module     "english-dictionary"
+                 :pathname   "code"
+                 :depends-on ("code"
+                              "english-dictionary-data")
+                 :components ((:file "english"))))
 
   :in-order-to ((test-op (test-op "spell/test"))))
 

--- a/test/english.lisp
+++ b/test/english.lisp
@@ -7,7 +7,10 @@
   "Test dictionary lookup with strings that are not existing words."
   (is (null (spell:english-lookup "no-such-word")))
   ;; A prefix of an existing word exercises a different code path.
-  (is (null (spell:english-lookup "fuc"))))
+  (is (null (spell:english-lookup "fuc")))
+  ;; A an existing word with an non-existing suffix exercises yet
+  ;; another code path.
+  (spell:english-lookup "test'sxxx"))
 
 (test english.compare
   "Compare dictionary data structure to ground truth from dictionary file."

--- a/test/english.lisp
+++ b/test/english.lisp
@@ -27,6 +27,6 @@
           (some (lambda (result)
                   (result-matches-p result expected-class base initargs))
                 results)
-          "~@<For ~S ~S [base ~S]~@[ initiargs ~{~S~^ ~}~], none of the ~
+          "~@<For ~S ~S [base ~S]~@[ initargs ~{~S~^ ~}~], none of the ~
            results ~{~A~^, ~} matches the expected properties.~@:>"
           type word base initargs results))))))


### PR DESCRIPTION
Regarding the dependencies between data and code, we should eventually go a bit further and separate the dictionary "support" code for loading, lookup and paragraph processing from the `*english-dictionary*` so that the amount of recompilation is minimized.
Separating things like that would also remove the need for `eval-when` around `load-english-dictionary`.